### PR TITLE
Excluded common plugins non vital data.

### DIFF
--- a/src/CliCommand.php
+++ b/src/CliCommand.php
@@ -94,19 +94,22 @@ class CliCommand extends \WP_CLI_Command {
         'add-drop-table' => TRUE,
       ]);
       $tableWheres = apply_filters(static::PREFIX . '/table-wheres', [
+        "{$wpdb->prefix}comments" => "comment_post_ID IN ({$allowedOrderIds})",
         "{$wpdb->prefix}users" => "ID IN ({$allowedUserIds})",
         "{$wpdb->prefix}usermeta" => "user_id IN ({$allowedUserIds})",
-        "{$wpdb->prefix}woocommerce_order_items" => "order_id IN ({$allowedOrderIds})",
-        "{$wpdb->prefix}woocommerce_order_itemmeta" => "order_item_id IN ({$allowedOrderItemIds})",
+        "{$wpdb->prefix}options" => 'option_name NOT LIKE "_transient_%" AND option_name NOT LIKE "_cache_%"',
         "{$wpdb->prefix}posts" => implode(' AND ', $postTableWheres),
         "{$wpdb->prefix}postmeta" => "post_id NOT IN (SELECT p.ID FROM {$wpdb->prefix}posts p WHERE " . implode(' AND ', $postTableWheres) . ")",
-        // Ignore unnnecessary info.
+      ]);
+
+      // Remove woocommerce related entries.
+      $tableWheres = array_merge($tableWheres, [
         "{$wpdb->prefix}actionscheduler_actions" => '1 = 0',
         "{$wpdb->prefix}actionscheduler_claims" => '1 = 0',
         "{$wpdb->prefix}actionscheduler_groups" => '1 = 0',
         "{$wpdb->prefix}actionscheduler_logs" => '1 = 0',
-        "{$wpdb->prefix}comments" => "comment_post_ID IN ({$allowedOrderIds})",
-        "{$wpdb->prefix}options" => 'option_name NOT LIKE "_transient_%" AND option_name NOT LIKE "_cache_%"',
+        "{$wpdb->prefix}woocommerce_order_items" => "order_id IN ({$allowedOrderIds})",
+        "{$wpdb->prefix}woocommerce_order_itemmeta" => "order_item_id IN ({$allowedOrderItemIds})",
         "{$wpdb->prefix}woocommerce_sessions" => '1 = 0',
       ]);
 


### PR DESCRIPTION
- Fixes #8 
- Fixes #9 
- Fixes #10 
- Fixes #12 
- Fixes #13 
- Fixes #14 
- Fixes #16 

### Description
- this manages to reduce a 2.4 Gb database fro latest dump of GACO to a ~545M export file
### Note
- this should be refactored to add a filter for plugins to exclude or not
- it is time to spread the code into classes, before it gets too convoluted
