### PR TITLE
Fixed slow allowed users query due to use of regex.

### DIFF
--- a/src/CliCommand.php
+++ b/src/CliCommand.php
@@ -68,9 +68,10 @@ class CliCommand extends \WP_CLI_Command {
     $databaseTableCount = $wpdb->get_col($wpdb->prepare("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '%s'", DB_NAME))[0];
 
     // Retain user ids about to be skipped for further filters.
+    $emailsPlaceholder = implode(',', array_fill(0, count($allowedEmails), '%s'));
     $allowedUserIds = implode(',', $wpdb->get_col(
-      $wpdb->prepare("SELECT u.ID FROM {$wpdb->prefix}users u WHERE u.user_email REGEXP ('%s')", implode('|', $allowedEmails)
-    )));
+      $wpdb->prepare("SELECT u.ID FROM {$wpdb->prefix}users u WHERE u.user_email IN ({$emailsPlaceholder})", $allowedEmails)
+    ));
     $allowedUserIds = apply_filters(static::PREFIX . '/allowed-user-ids', $allowedUserIds);
 
     // Retain only order/subscription IDs corresponding to allowed users.


### PR DESCRIPTION
### Ticket
- []()

### Description
- the problem was using `regexp`, it looks like this was slowing the query by ~ 0.5-1 sec

#### Before
![image](https://user-images.githubusercontent.com/11241985/140777108-cb7c7a48-35df-49e7-bbac-df38a646072d.png)


#### After 
![image](https://user-images.githubusercontent.com/11241985/140776807-ea71ac71-133e-43be-8412-8d60a27743a5.png)

